### PR TITLE
Add transition to smooth figure movement, improve styling on .invalid-position

### DIFF
--- a/WebEditor/Components/Board/ElementRenderer.razor.css
+++ b/WebEditor/Components/Board/ElementRenderer.razor.css
@@ -6,7 +6,6 @@
     top: calc(var(--pos-y) * var(--cell-size) + var(--figure-margin));
     z-index: 1;
     pointer-events: none;
-
 }
 
 .dragged-element

--- a/WebEditor/Components/Board/ElementRenderer.razor.css
+++ b/WebEditor/Components/Board/ElementRenderer.razor.css
@@ -6,6 +6,7 @@
     top: calc(var(--pos-y) * var(--cell-size) + var(--figure-margin));
     z-index: 1;
     pointer-events: none;
+
 }
 
 .dragged-element
@@ -13,13 +14,15 @@
     opacity: .5;
     border: 2px solid lightgreen;
     pointer-events: none;
+    transition: cubic-bezier(0, 0, 0, 1) 150ms;
 }
 
-.invalid-position
+.invalid-position 
 {
     position: absolute;
     width: 100%;
     height: 100%;
     z-index: 2;
-    background-color: red;
+    background-color: darkred;
+    border: 2px solid red;
 }


### PR DESCRIPTION
### Details
- Added a `transition` with `cubic-bezier(0, 0, 0, 1)` at `150ms`
- Changed `background-color` to `darkred` and set `border` to `2px solid red` on `.invalid-position`
  ![New "Invalid Placement" look](https://github.com/CaptainCoderOrg/TacticsEngine/assets/95766563/6c5f8e65-8421-466d-b2a4-231ace94a222)
