### PR TITLE
Styling adjustments

### DIFF
--- a/WebEditor/Components/Board/ElementRenderer.razor.css
+++ b/WebEditor/Components/Board/ElementRenderer.razor.css
@@ -1,5 +1,4 @@
-.positioned-element
-{
+.positioned-element {
     position: absolute;
     --figure-margin: 2px;
     left: calc(var(--pos-x) * var(--cell-size) + var(--figure-margin));
@@ -8,20 +7,20 @@
     pointer-events: none;
 }
 
-.dragged-element
-{
+.dragged-element {
     opacity: .5;
     border: 2px solid lightgreen;
     pointer-events: none;
     transition: cubic-bezier(0, 0, 0, 1) 150ms;
+    margin: -2px -2px;
 }
 
-.invalid-position 
-{
+.invalid-position {
     position: absolute;
     width: 100%;
     height: 100%;
     z-index: 2;
     background-color: darkred;
     border: 2px solid red;
+    margin: -2px -2px;
 }

--- a/WebEditor/Components/Board/ElementRenderer.razor.css
+++ b/WebEditor/Components/Board/ElementRenderer.razor.css
@@ -23,4 +23,5 @@
     background-color: darkred;
     border: 2px solid red;
     margin: -2px -2px;
+    box-shadow: red 0px 0px 16px;
 }

--- a/WebEditor/Components/Panels/FigurePanel.razor.css
+++ b/WebEditor/Components/Panels/FigurePanel.razor.css
@@ -1,5 +1,8 @@
 h2 {
     margin: 0;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 .figure-panel {
     --cell-size: 25px;


### PR DESCRIPTION
### Changes
- Added a red glow on `.invalid-position`
- Fixed positioning of `.dragged-element` and `.invalid-position`
- Disabled text selection on `h2` in FigurePanel to prevent unintended behavior in Microsoft Edge