### PR TITLE
63 dragging figure fails when window must scroll

### DIFF
--- a/WebEditor/Components/DragAndDrop/BoardDragGrid.razor.css
+++ b/WebEditor/Components/DragAndDrop/BoardDragGrid.razor.css
@@ -1,7 +1,7 @@
 ﻿.drag-grid-container {
     position: absolute;
-    width: 100%;
-    height: 100%;
+    width: calc(var(--board-width) * var(--cell-size));
+    height: calc(var(--board-height) * var(--cell-size));
 }
 
 .on-top {

--- a/WebEditor/Components/Editors/BoardEditor.razor
+++ b/WebEditor/Components/Editors/BoardEditor.razor
@@ -78,15 +78,6 @@
 
     protected override void OnInitialized()
     {
-        _board = new()
-            {
-                Tiles = [.. new BoundingBox(new Position(2, 2), 10, 10).Positions()],
-                Figures = [
-                    new (new Figure(), new Position(3, 3)),
-                new (new Figure(2, 1), new Position(5, 2)),
-                new (new Figure(1, 2), new Position(2, 5)),
-                new (new Figure(3, 2), new Position(7, 7)),
-            ]
-            };
+        _board = new();
     }
 }


### PR DESCRIPTION
- **chore: Board starts empty.**
- **fix: Update drag-grid-container to be the width of the board.**
